### PR TITLE
fix: fix broken links to point to correct endpoint

### DIFF
--- a/.link-checker.config.json
+++ b/.link-checker.config.json
@@ -1,0 +1,8 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "dao.arrowair.com/t/aip-###"
+    }
+  ]
+}
+

--- a/AIPs/AIP-001.md
+++ b/AIPs/AIP-001.md
@@ -2,8 +2,8 @@
 AIP: 001
 title: AIP Purpose and Guidelines
 description: Information on Arrow Improvement Proposals (AIPs) and the AIP process
-author: [Sleety](https://github.com/sl33ty)
-discussions-to: https://dao.arrowair.com/t/aip-001-discussion-aip-purpose-guidelines/24
+author: Sleety (https://github.com/sl33ty)
+discussions-to: https://dao.arrowair.com/t/AIP-001-discussion-aip-purpose-guidelines/24
 status: Review
 type: operational
 created: 2024-08-05
@@ -12,9 +12,9 @@ created: 2024-08-05
 ## Summary: What is an AIP?
 AIP stands for Arrow Improvement Proposal. An AIP is a design document providing information to the Arrow community or describing a new feature for Arrow. We intend for AIPs to be the primary mechanism for proposing new features and documenting the operational and organizational improvements of Arrow DAO.
 
-The precise format for AIPs is detailed below, and a template is located [here](https://www.github.com/arrow-air/dao-aips/aip-template.md)
+The precise format for AIPs is detailed below, and a template is located [here](https://github.com/Arrow-air/dao-aips/blob/main/AIP-template.md)
 
-Only AIPs in the “Final” state are eligible for adoption and must be reviewed by editors before marked as “Final”. If you want to contribute to an existing “Draft” AIP, coordinate with the original author(s) to submit a PR. If you want to work on a new AIP, contact any of the AIP editors listed [here](https://www.github.com/arrow-air/dao-aips/aips/aip-003.md)
+Only AIPs in the “Final” state are eligible for adoption and must be reviewed by editors before marked as “Final”. If you want to contribute to an existing “Draft” AIP, coordinate with the original author(s) to submit a PR. If you want to work on a new AIP, contact any of the AIP editors listed [here](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-003.md)
 
 **The AIP author is responsible for building consensus within the community and documenting dissenting opinions.**
 
@@ -23,9 +23,9 @@ Only AIPs in the “Final” state are eligible for adoption and must be reviewe
 ### Shepherding an AIP
 Parties involved in the process are you (i.e. the champion or AIP author), the AIP Editors, and the Arrow community.
 
-Before you begin writing a formal AIP, you should vet your idea. Ask the Arrow community on the [Discord server](discord.gg/arrow) or [DAO Forum](https://dao.arrowair.com/c/arrow-improvement-proposals) first if an idea is original to avoid wasting time on something that will be rejected based on prior research. 
+Before you begin writing a formal AIP, you should vet your idea. Ask the Arrow community on the [Discord server](https://discord.gg/arrow) or [DAO Forum](https://dao.arrowair.com/c/arrow-improvement-proposals) first if an idea is original to avoid wasting time on something that will be rejected based on prior research. 
 
-It is highly recommended that a single AIP should contain a single key proposal or new idea. The more focused the AIP, the more successful the ensuing process tends to be. Template for new AIPs is available [here](https://www.github.com/arrow-air/dao-aips/aip-template.md).
+It is highly recommended that a single AIP should contain a single key proposal or new idea. The more focused the AIP, the more successful the ensuing process tends to be. Template for new AIPs is available [here](https://github.com/Arrow-air/dao-aips/blob/main/AIP-template.md).
 
 Once the idea has been vetted, your next responsibility will be to present a Draft AIP to the Arrow community to begin the first tracked stage of the AIP process. This draft can exist as a work in progress by the Author and can remain in an incubation state if the idea or implementation needs to be developed further. Once the document is mature and ready for wider community feedback it goes to the Review stage i.e. ready for review/constructive feedback.
 
@@ -60,12 +60,12 @@ The following is the standardization process for all AIPs:
 **Obsolete** - An Obsolete AIP has been replaced, superseded or removed.
 Only Final and Living AIPs are eligible for official adoption.
 
-![AIP Process Diagram](../assets/aip-001/AIP-process-diagram.png)
+![AIP Process Diagram](https://raw.githubusercontent.com/Arrow-air/dao-aips/main/assets/aip-001/AIP-process-diagram.png)
 
 ## AIP Templates and Formats
 
 ### AIPs
-AIPs should be written in markdown format. AIP Template available [here](https://www.github.com/arrow-air/dao-aips/aip-template.md)
+AIPs should be written in markdown format. AIP Template available [here](https://github.com/Arrow-air/dao-aips/blob/main/AIP-template.md)
 
 ### AIP Header Preamble
 
@@ -131,7 +131,7 @@ Images, diagrams and auxiliary files should be included in a subdirectory of the
 
 ## AIP Editors
 
-Current and historic AIP editors are recorded in [AIP-003](https://www.github.com/arrow-air/dao-aips/aips/aip-003.md).
+Current and historic AIP editors are recorded in [AIP-003](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-003.md).
 
 ## AIP Editor Responsibilities
 

--- a/AIPs/AIP-002.md
+++ b/AIPs/AIP-002.md
@@ -3,7 +3,7 @@ AIP: 2
 title: Creation of Grants and Bounties Committee
 description: Establishing an entity to oversee coordination and payment of bounties and grants
 author: Sleety (@sl33ty)
-discussions-to: https://dao.arrowair.com/t/aip-002-discussion-creation-of-grants-and-bounties-committee/31
+discussions-to: https://dao.arrowair.com/t/AIP-002-discussion-creation-of-grants-and-bounties-committee/31
 status: Draft
 type: operational
 created: 2024-08-01
@@ -44,7 +44,7 @@ The GBC SHALL abide by the following definitions for grants, bounties, commitmen
 
 **Time Commitment Grant**: A proposal submitted by an individual that proposes compensation for tasks and activities deemed necessary for ongoing daily work and discussions related to critical areas of the DAO. 
 
-**Retrospective Award**: A proposal submitted by an individual or group that proposes a payment for a previously-achieved result. The retrospective award SHOULD detail the work that was completed and the positive impacts for the DAO that would merit such an award. The entity that submitted the retrospective award proposal MAY or MAY NOT be the person(s) awarded a retrospective award for the work documented in the proposal. The retrospective award SHOULD be awarded in a blend of USDC or similar stablecoin and/or ARROW token as per Time Commitment Grant compensation guidelines (see [AIP-004](https://www.github.com/arrow-air/dao-aips/aips/aip-004.md)). Calculations of ARROW token amounts SHALL NOT include expenses, which are processed as reimbursement receipts.
+**Retrospective Award**: A proposal submitted by an individual or group that proposes a payment for a previously-achieved result. The retrospective award SHOULD detail the work that was completed and the positive impacts for the DAO that would merit such an award. The entity that submitted the retrospective award proposal MAY or MAY NOT be the person(s) awarded a retrospective award for the work documented in the proposal. The retrospective award SHOULD be awarded in a blend of USDC or similar stablecoin and/or ARROW token as per Time Commitment Grant compensation guidelines (see [AIP-004](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-004.md)). Calculations of ARROW token amounts SHALL NOT include expenses, which are processed as reimbursement receipts.
 
 ### Difference Between Bounties & Grants
 
@@ -106,7 +106,7 @@ The GBC will act according to the following:
 
 - The GBC SHOULD be eligible for monetary compensation via a stipend or bounty for their time.
 
-- For the initial selection process, 5 members SHALL be selected. A list of active and historic members of the GBC SHALL be provided in a publicly-available document [see AIP-003](https://www.github.com/arrow-air/dao-aips/aips/aip-003.md).
+- For the initial selection process, 5 members SHALL be selected. A list of active and historic members of the GBC SHALL be provided in a publicly-available document [see AIP-003](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-003.md).
 
 - Arrow contributors interested in becoming inaugural members of the GBC SHOULD nominate themselves through an informal voting method on the forum and/or Discord.
 

--- a/about-AIPs.md
+++ b/about-AIPs.md
@@ -3,9 +3,9 @@
 Arrow Improvement Proposals (AIPs) describe standards for Arrow, including operational and governance procedures.
 
 ## Contributing 
-1. First step is to review [AIP-001](https://www.github.com/arrow-air/dao-aips/aip-001.md). 
-2. Then clone the [AIP repository](https://www.github.com/arrow-air/dao-aips/aips) and add your AIP to it. Template for new AIPs can be found [here](https://www.github.com/arrow-air/dao-aips/aip-template.md).
-3. Then submit a Pull Request to Arrow's [AIP repository](https://www.github.com/arrow-air/dao-aips/aips).
+1. First step is to review [AIP-001](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-001.md). 
+2. Then clone the [AIP repository](https://github.com/Arrow-air/dao-aips/blob/main/AIPs) and add your AIP to it. Template for new AIPs can be found [here](https://github.com/Arrow-air/dao-aips/blob/main/AIP-template.md).
+3. Then submit a Pull Request to Arrow's [AIP repository](https://github.com/Arrow-air/dao-aips/blob/main/AIPs).
 
 ## AIP Types
 AIPs are separated into a different types.
@@ -27,15 +27,15 @@ AIPs are separated into a different types.
 
 **Final** - A Final AIP exists in a state of finality and should only be updated for spelling or grammar corrections and additional context, not for consequential changes. 
 
-**Stagnant** - Any AIP in Draft or Review which is inactive for too long is moved to Stagnant. An AIP may be resurrected by simply requesting this status change from an [AIP Editor](https://www.github.com/arrow-air/dao-aips/aip-003.md).
+**Stagnant** - Any AIP in Draft or Review which is inactive for too long is moved to Stagnant. An AIP may be resurrected by simply requesting this status change from an [AIP Editor](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-003.md).
 
 **Withdrawn** - The AIP Author(s) have withdrawn the proposed AIP. This state has finality and can no longer be resurrected using this AIP number. If the idea is pursued at a later date it is considered a new proposal.
 
-**Living** - A special status for AIPs that are designed to be continually updated and not reach a state of finality. This includes most notably [AIP-001](https://www.github.com/arrow-air/dao-aips/aip-003.md) (AIP Purpose & Guidelines).
+**Living** - A special status for AIPs that are designed to be continually updated and not reach a state of finality. This includes most notably [AIP-001](https://github.com/Arrow-air/dao-aips/blob/main/AIPs/AIP-003.md) (AIP Purpose & Guidelines).
 
 **Obsolete** - An Obsolete AIP has been replaced, superseded or removed.
 
-![AIP Process Diagram](/assets/about-AIPs/AIP-process-diagram.png).
+![AIP Process Diagram](https://raw.githubusercontent.com/Arrow-air/dao-aips/main/assets/about-AIPs/AIP-process-diagram.png).
 
 Only Final and Living AIPs are eligible for official adoption.
 


### PR DESCRIPTION
All github links didn't contain the `blob/main` part in the URL which results in 404 when followed.
In addition, the assets links now point to the actual URL rather than using a relative path so that the MD content can be copied over safely without displaying broken images.

The link to AIP-004 remains broken since it hasn't been added yet to the `main` branch of this repository