### PR TITLE
Replace "charter" with a link to RFC 2119 in the AIP template

### DIFF
--- a/AIP-template.md
+++ b/AIP-template.md
@@ -26,7 +26,8 @@ Abstract is a multi-sentence (short paragraph) technical summary. This should be
 The motivation section should describe the "why" of this AIP. What problem does it solve? Why should someone want to implement this standard? What benefit does it provide to the Arrow ecosystem? What use cases does this AIP address?
 
 ## Specification
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in charter.
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
 The technical specification should describe the syntax and semantics of any new feature.
 


### PR DESCRIPTION
@sl33ty I found the mention of "charter" in the AIP template to be confusing and was wondering if it was in error. The same text in AIP-001 mentions RFC 2119 and that seems more appropriate to me in the template as well